### PR TITLE
Allow config to be passed by object in loader options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 _build/
 *.tgz
+node_modules

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,8 +30,16 @@ export default <loader.Loader>function(
 	// updated
 	const _sourceMap = <RawSourceMap>sourceMap;
 
-	getConfig(options.config)
-		.then(({ config, file }) => {
+	let configPromise: Promise<{ config: any, file?: any }>;
+
+	if (typeof options.config === 'object') {
+		configPromise = Promise.resolve(options.config);
+	}
+	else {
+		configPromise = getConfig(options.config);
+	}
+
+	configPromise.then(({ config, file }) => {
 			// If a config file was successfully loaded, mark it as a dependency
 			if (file) {
 				this.addDependency(file);


### PR DESCRIPTION
Allows an object to be passed for the config rather than just a path to the intern file. The types and tests aren't great generally in this package (there isn't even a test for passing the option in the first place), so I just made the minimal amount of disruptive changes in source and test.